### PR TITLE
NewerNewChunks: auto-follow tuning (direction lock, no-backtrack, turn-aware chain)

### DIFF
--- a/src/main/java/pwn/noobs/trouserstreak/modules/NewerNewChunks.java
+++ b/src/main/java/pwn/noobs/trouserstreak/modules/NewerNewChunks.java
@@ -1162,7 +1162,9 @@ public class NewerNewChunks extends Module {
                 if (lastCompletedTarget != null && System.currentTimeMillis() - lastCompletedAt < BACKTRACK_COOLDOWN_MS && candidate.equals(lastCompletedTarget))
                     continue;
                 if (pool.contains(candidate)) {
-                    if (ahead <= 1 || hasChainLinear(candidate, pool, ahead - 1, dir)) return candidate;
+                    // Accept if straight chain continues OR if a valid chain exists allowing turns
+                    if (ahead <= 1 || hasChainLinear(candidate, pool, ahead - 1, dir) || hasChain(candidate, pool, ahead - 1, start))
+                        return candidate;
                 }
             }
         }


### PR DESCRIPTION
Summary\n- Direction lock: locks initial look-based direction once at start.\n- No-backtrack: disallows backwards candidates; cooldown avoids ping-pong.\n- Turn-aware chain: allows look-ahead chains to include turns while maintaining non-negative forward projection; keeps forward bias and gap allowance.\n\nSettings guidance\n- look-ahead-chunks: 3 (2–3 if the trail turns often)\n- search-radius-chunks: 10–12\n- gap-allowance-chunks: 1–2\n- pause-on-input: true\n\nImplementation\n- File: src/main/java/pwn/noobs/trouserstreak/modules/NewerNewChunks.java\n- Methods: updateAutoFollow, pickNextTarget, hasChain/hasChainLinear, helpers for direction lock/projection checks.\n\nManual test plan\n1) Face desired direction; enable auto-follow; verify forward progression.\n2) At turns, confirm it continues along the trail without backtracking.\n3) Provide input to pause/resume; verify behavior.\n4) With no targets, verify it cancels pathing per settings.\n\nNotes\n- Baritone kept via reflection; no API dependency changes.