### PR TITLE
NewerNewChunks: refactor auto-follow to route by chunk (2D, recalc-on-goal)

### DIFF
--- a/src/main/java/pwn/noobs/trouserstreak/modules/NewerNewChunks.java
+++ b/src/main/java/pwn/noobs/trouserstreak/modules/NewerNewChunks.java
@@ -307,8 +307,9 @@ public class NewerNewChunks extends Module {
 
     // Auto-follow state
     private ChunkPos currentTarget = null;
-    private long lastSetGoalTime = 0L;
     private boolean baritoneWarned = false;
+    // Route planning: maintain a queue of chunks to traverse in order. Only recompute when route is exhausted.
+    private final Deque<ChunkPos> routeQueue = new ArrayDeque<>();
     // Anti-oscillation: remember last completed target for a short cooldown window
     private ChunkPos lastCompletedTarget = null;
     private long lastCompletedAt = 0L;
@@ -670,7 +671,7 @@ public class NewerNewChunks extends Module {
 
 		if (removerenderdist.get())removeChunksOutsideRenderDistance();
 
-		// Auto-follow tick
+        // Auto-follow tick
         if (autoFollow.get()) {
             if (!baritoneAvailable()) {
                 if (!baritoneWarned) { info("Baritone not found. Auto-follow will not path."); baritoneWarned = true; }
@@ -1140,17 +1141,27 @@ public class NewerNewChunks extends Module {
 
         ChunkPos playerChunk = new ChunkPos(mc.player.getBlockX() >> 4, mc.player.getBlockZ() >> 4);
 
-        // If in current target, clear it to pick next
+        // If standing in current target, advance to next waypoint on the precomputed route
         if (currentTarget != null && isWithinChunk(currentTarget, mc.player.getBlockPos())) {
-            logFollow("Reached target chunk " + currentTarget.x + "," + currentTarget.z + ", selecting next.");
-            // Mark last completed to avoid immediate backtracking/ping-pong
+            logFollow("Reached waypoint chunk " + currentTarget.x + "," + currentTarget.z + ".");
             lastCompletedTarget = currentTarget;
             lastCompletedAt = System.currentTimeMillis();
+            // consume current waypoint
+            if (!routeQueue.isEmpty() && routeQueue.peekFirst().equals(currentTarget)) routeQueue.pollFirst();
             currentTarget = null;
         }
 
-        // Pick or refresh target periodically
-        if (currentTarget == null || System.currentTimeMillis() - lastSetGoalTime > 2000) {
+        // If no active waypoint, either continue with next in route or compute a new route
+        if (currentTarget == null) {
+            if (!routeQueue.isEmpty()) {
+                ChunkPos next = routeQueue.peekFirst();
+                currentTarget = next;
+                logFollow("Next waypoint chunk " + next.x + "," + next.z + ".");
+                setGoalForChunk(next);
+                return;
+            }
+
+            // Build a new route from the player's current chunk
             Direction[] dirOrder = lockedDirOrder;
             if (dirOrder == null) {
                 dirOrder = getLookOrderedDirs();
@@ -1158,13 +1169,18 @@ public class NewerNewChunks extends Module {
                 initialForwardDir = dirOrder[0];
                 logFollow("Direction locked to " + initialForwardDir + ".");
             }
-            ChunkPos next = pickNextTarget(playerChunk, pool, lookAhead.get(), searchRadius.get(), maxGap.get(), dirOrder, initialForwardDir);
-            if (next != null && !next.equals(currentTarget)) {
-                currentTarget = next;
-                logFollow("New target chunk " + next.x + "," + next.z +
-                    " (ahead=" + lookAhead.get() + ", radius=" + searchRadius.get() + ").");
-                setGoalForChunk(next);
-                lastSetGoalTime = System.currentTimeMillis();
+            List<ChunkPos> route = buildRoute(playerChunk, pool, lookAhead.get(), searchRadius.get(), maxGap.get(), dirOrder, initialForwardDir);
+            if (!route.isEmpty()) {
+                // If route starts at current chunk, drop it
+                if (route.get(0).equals(playerChunk)) route.remove(0);
+                routeQueue.clear();
+                routeQueue.addAll(route);
+                ChunkPos next = routeQueue.peekFirst();
+                if (next != null) {
+                    currentTarget = next;
+                    logFollow("New route with " + routeQueue.size() + " waypoints. Heading to " + next.x + "," + next.z + ".");
+                    setGoalForChunk(next);
+                }
             }
         }
     }
@@ -1180,27 +1196,70 @@ public class NewerNewChunks extends Module {
 		return null;
 	}
 
-    private ChunkPos pickNextTarget(ChunkPos start, Set<ChunkPos> pool, int ahead, int radius, int maxGap, Direction[] dirOrder, Direction forward) {
-        // Prefer forward direction based on look; allow skipping up to maxGap non-target chunks
-        for (Direction dir : dirOrder) {
-            for (int step = 1; step <= Math.max(1, maxGap + 1); step++) {
-                ChunkPos candidate = new ChunkPos(start.x + dir.getOffsetX() * step, start.z + dir.getOffsetZ() * step);
-                // Skip immediate backtrack candidate during cooldown window
-                if (lastCompletedTarget != null && System.currentTimeMillis() - lastCompletedAt < BACKTRACK_COOLDOWN_MS && candidate.equals(lastCompletedTarget))
+    private List<ChunkPos> buildRoute(ChunkPos start, Set<ChunkPos> pool, int maxSteps, int radius, int maxGap, Direction[] dirOrder, Direction forward) {
+        List<ChunkPos> route = new ArrayList<>(Math.max(4, maxSteps));
+        ChunkPos cur = start;
+        int steps = 0;
+
+        // Greedy route: prefer forward, allow small gaps, then lateral directions; avoid backtracking
+        while (steps < maxSteps) {
+            ChunkPos next = null;
+
+            // 1) Try straight ahead with gap allowance
+            for (Direction dir : dirOrder) {
+                // Do not go backwards relative to initial forward
+                if (forward != null && !isForwardOrLateral(start, new ChunkPos(cur.x + dir.getOffsetX(), cur.z + dir.getOffsetZ()), forward))
                     continue;
-                // Never go backwards relative to initial forward direction
-                if (forward != null && !isForwardOrLateral(start, candidate, forward)) continue;
-                if (pool.contains(candidate)) {
-                    // Accept if straight chain continues OR if a valid chain exists allowing turns (but not backwards)
-                    if (ahead <= 1
-                        || hasChainLinear(candidate, pool, ahead - 1, dir, forward, start)
-                        || hasChain(candidate, pool, ahead - 1, start, forward, start))
-                        return candidate;
+
+                // exact neighbor
+                ChunkPos candidate = new ChunkPos(cur.x + dir.getOffsetX(), cur.z + dir.getOffsetZ());
+                if (pool.contains(candidate)) { next = candidate; break; }
+
+                // gap-bridge: allow stepping over non-pool chunks to reach a pool chunk
+                for (int gap = 1; gap <= maxGap; gap++) {
+                    ChunkPos far = new ChunkPos(cur.x + dir.getOffsetX() * (gap + 1), cur.z + dir.getOffsetZ() * (gap + 1));
+                    if (pool.contains(far)) {
+                        // Add intermediates to encourage staying aligned to chunk grid
+                        for (int i = 1; i <= gap + 1 && steps < maxSteps; i++) {
+                            ChunkPos mid = new ChunkPos(cur.x + dir.getOffsetX() * i, cur.z + dir.getOffsetZ() * i);
+                            // Avoid duplicates and backtracking to the just-completed target
+                            if (lastCompletedTarget != null && System.currentTimeMillis() - lastCompletedAt < BACKTRACK_COOLDOWN_MS && mid.equals(lastCompletedTarget))
+                                continue;
+                            route.add(mid);
+                            steps++;
+                            if (steps >= maxSteps) break;
+                        }
+                        cur = route.get(route.size() - 1);
+                        next = null; // Already appended intermediates up to far; loop will continue
+                        break;
+                    }
                 }
+                if (next != null) break;
             }
+
+            if (next == null) {
+                // 2) Fallback to nearest in radius that is forward/lateral
+                ChunkPos nearest = nearestInRadius(cur, pool, radius, forward, start);
+                if (nearest == null) break;
+                next = nearest;
+            }
+
+            // Avoid immediate backtracking
+            if (lastCompletedTarget != null && System.currentTimeMillis() - lastCompletedAt < BACKTRACK_COOLDOWN_MS && next.equals(lastCompletedTarget))
+                break;
+
+            // Append and move on
+            if (steps < maxSteps) {
+                route.add(next);
+                steps++;
+                cur = next;
+            } else break;
         }
 
-        // Fallback: nearest in radius
+        return route;
+    }
+
+    private ChunkPos nearestInRadius(ChunkPos start, Set<ChunkPos> pool, int radius, Direction forward, ChunkPos originStart) {
         ChunkPos best = null;
         double bestDist = Double.MAX_VALUE;
         int minX = start.x - radius, maxX = start.x + radius;
@@ -1209,15 +1268,12 @@ public class NewerNewChunks extends Module {
             if (cp == null) continue;
             if (lastCompletedTarget != null && System.currentTimeMillis() - lastCompletedAt < BACKTRACK_COOLDOWN_MS && cp.equals(lastCompletedTarget))
                 continue;
-            if (forward != null && !isForwardOrLateral(start, cp, forward)) continue;
+            if (forward != null && !isForwardOrLateral(originStart, cp, forward)) continue;
             if (cp.x < minX || cp.x > maxX || cp.z < minZ || cp.z > maxZ) continue;
             double dx = (cp.x - start.x);
             double dz = (cp.z - start.z);
             double d2 = dx * dx + dz * dz;
-            if (d2 < bestDist) {
-                bestDist = d2;
-                best = cp;
-            }
+            if (d2 < bestDist) { bestDist = d2; best = cp; }
         }
         return best;
     }
@@ -1251,16 +1307,17 @@ public class NewerNewChunks extends Module {
         if (mc.world == null) return;
         int cx = cp.getCenterX();
         int cz = cp.getCenterZ();
-        int y;
-        if (pathingMode.get() == PathingMode.Elytra) {
-            // Aim high to encourage elytra traversal; enable normal path fallback if needed
-            y = Math.min(300, getTopYAt(cx, cz) + 32);
-        } else {
-            y = getTopYAt(cx, cz);
+        // Ignore Y axis: prefer Baritone GoalXZ if available
+        logFollow("Setting Baritone goal (XZ only) to (" + cx + "," + cz + ").");
+        try {
+            baritoneSetGoalXZ(cx, cz);
+        } catch (Throwable t) {
+            // Fallback to GoalBlock at terrain height if GoalXZ unavailable
+            int y = (pathingMode.get() == PathingMode.Elytra) ? Math.min(300, getTopYAt(cx, cz) + 32) : getTopYAt(cx, cz);
+            BlockPos goalPos = new BlockPos(cx, y, cz);
+            logFollow("GoalXZ unavailable; falling back to GoalBlock at Y=" + y + ".");
+            try { baritoneSetGoal(goalPos); } catch (Throwable t2) { logFollow("Failed to set fallback goal: " + t2.getClass().getSimpleName() + (t2.getMessage() != null ? (" - " + t2.getMessage()) : "")); }
         }
-        BlockPos goalPos = new BlockPos(cx, y, cz);
-        logFollow("Setting Baritone goal to (" + goalPos.getX() + "," + goalPos.getY() + "," + goalPos.getZ() + ") via " + pathingMode.get() + ".");
-        try { baritoneSetGoal(goalPos); } catch (Throwable t) { logFollow("Failed to set goal: " + t.getClass().getSimpleName() + (t.getMessage() != null ? (" - " + t.getMessage()) : "")); }
     }
 
     private int getTopYAt(int x, int z) {
@@ -1402,6 +1459,29 @@ public class NewerNewChunks extends Module {
                 // Some versions path automatically on setGoal
                 logFollow("No path() method; assuming automatic pathing.");
             }
+        }
+    }
+
+    private void baritoneSetGoalXZ(int x, int z) throws Exception {
+        Class<?> api = Class.forName("baritone.api.BaritoneAPI");
+        Object provider = api.getMethod("getProvider").invoke(null);
+        Object baritone = provider.getClass().getMethod("getPrimaryBaritone").invoke(provider);
+        if (baritone == null) return;
+
+        Object goalProcess = baritone.getClass().getMethod("getCustomGoalProcess").invoke(baritone);
+        // Support Goal and IGoal
+        Class<?> goalIface;
+        try { goalIface = Class.forName("baritone.api.pathing.goals.Goal"); }
+        catch (ClassNotFoundException e) { goalIface = Class.forName("baritone.api.pathing.goals.IGoal"); }
+
+        // Prefer GoalXZ if present
+        Class<?> goalXZ = Class.forName("baritone.api.pathing.goals.GoalXZ");
+        Object goal = goalXZ.getConstructor(int.class, int.class).newInstance(x, z);
+        try {
+            goalProcess.getClass().getMethod("setGoalAndPath", goalIface).invoke(goalProcess, goal);
+        } catch (NoSuchMethodException e) {
+            goalProcess.getClass().getMethod("setGoal", goalIface).invoke(goalProcess, goal);
+            try { goalProcess.getClass().getMethod("path").invoke(goalProcess); } catch (NoSuchMethodException ignored) {}
         }
     }
 


### PR DESCRIPTION
This PR refactors auto-follow in NewerNewChunks to produce smoother, more reliable routing along detected chunk trails.\n\nKey changes:\n- Plans a multi-chunk route and sets sequential waypoints to encourage staying on the exact chunk trail.\n- Recalculates only when the precomputed route completes (no periodic timer-based refresh).\n- Uses Baritone GoalXZ to ignore Y when pathing (falls back to GoalBlock if unavailable).\n- Adds small gap bridging (configurable) and preserves direction via look-based locking to reduce zig-zagging.\n- Keeps existing pause-on-input + anti-backtrack safeguards.\n\nBuild:\n- Verified with