### PR TITLE
1.21.5: Chunk-follow HUD visibility, NotNew target, and UI-safe input checks

### DIFF
--- a/src/main/java/pwn/noobs/trouserstreak/hud/ChunkFollowStatsHud.java
+++ b/src/main/java/pwn/noobs/trouserstreak/hud/ChunkFollowStatsHud.java
@@ -57,7 +57,7 @@ public class ChunkFollowStatsHud extends HudElement {
     private final Setting<Boolean> hideWhenDisabled = sgGeneral.add(new BoolSetting.Builder()
         .name("hide-when-disabled")
         .description("Hide all lines when auto-follow is disabled.")
-        .defaultValue(true)
+        .defaultValue(false)
         .build()
     );
 
@@ -100,7 +100,7 @@ public class ChunkFollowStatsHud extends HudElement {
         int pool = mod.hudPoolSize();
 
         List<HUDLine> lines = new ArrayList<>();
-        lines.add(new HUDLine("Follow: " + followType + " (pool=" + pool + ")", Color.WHITE));
+        lines.add(new HUDLine("Follow: " + followType + (mod.hudAutoFollowEnabled() ? "" : " [OFF]") + " (pool=" + pool + ")", Color.WHITE));
         lines.add(new HUDLine("Target: " + targetStr, Color.WHITE));
         lines.add(new HUDLine("Heading: " + headStr, Color.WHITE));
         lines.add(new HUDLine("Apex: " + apexStr, Color.WHITE));
@@ -143,4 +143,3 @@ public class ChunkFollowStatsHud extends HudElement {
         HUDLine(String t, Color c) { text = t; color = c; }
     }
 }
-


### PR DESCRIPTION
This PR fixes three issues in NewerNewChunks for 1.21.5:\n\n- HUD visibility: The chunk-follow stats HUD now shows by default even when auto-follow is disabled (toggle via 'hide-when-disabled'). Adds an [OFF] indicator when auto-follow is off.\n- Target option: Adds 'NotNew' to follow all non-new chunk types (union of Old, BeingUpdated, OldGeneration, and BlockExploit).\n- Input handling: Auto-follow pause on input now ignores UI/screens (ClickGUI/HUD editor), so opening/navigating Meteor UI no longer disables auto-follow.\n\nFiles touched:\n- src/main/java/pwn/noobs/trouserstreak/hud/ChunkFollowStatsHud.java\n- src/main/java/pwn/noobs/trouserstreak/modules/NewerNewChunks.java\n\nBuild: ./gradlew build -x test (successful).